### PR TITLE
Adding support for multiple options to provide the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,15 @@ Authorization: Bearer <key>
 ```
 
 You can change where the API key is retrieved from by altering the setting in the `keyable.php` config file. Supported options are: `bearer`, `header`, and `parameter`. 
+
+As it is an array, you can use more than one of these options and combine them.
+
 ```php
 <?php
 	
 return [
 	
-    'mode' => 'header',
+    'modes' => ['header'],
 	
     'key' => 'X-Authorization',
 	
@@ -119,7 +122,7 @@ Need to pass the key as a URL parameter? Set the mode to `parameter` and the key
 	
 return [
 	
-    'mode' => 'parameter',
+    'modes' => ['parameter'],
 	
     'key' => 'api_key'
 	

--- a/config/keyable.php
+++ b/config/keyable.php
@@ -1,8 +1,8 @@
 <?php
-	
+
 return [
-	
-	/*
+
+    /*
     |--------------------------------------------------------------------------
     | Authentication Mode
     |--------------------------------------------------------------------------
@@ -10,14 +10,14 @@ return [
     | Supported modes: header, bearer, parameter
     |
     | When using header or parameter, set a key value.
-	|
+    |
     */
-    
-	'mode' => 'bearer',
-	
-	'key' => null,
-	
-	/*
+
+    'modes' => ['bearer'],
+
+    'key' => null,
+
+    /*
     |--------------------------------------------------------------------------
     | Empty Models
     |--------------------------------------------------------------------------
@@ -25,7 +25,7 @@ return [
     | Set this to true to allow API keys without an associated model.
     |
     */
-    
-	'allow_empty_models' => false,
-	
+
+    'allow_empty_models' => false,
+
 ];

--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -10,71 +10,86 @@ class AuthenticateApiKey
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @param Closure $next
-     * @param  string|null $guard
+     * @param string|null $guard
      * @return mixed
      */
     public function handle($request, Closure $next, $guard = null)
     {
-	    
-	    //Get API token from request
-	    $token = $this->getKeyFromRequest($request);
-	    
-	    //Check for presence of key
-	    if (!$token) return $this->unauthorizedResponse();
-	    
-		//Get API key
-		$apiKey = ApiKey::getByKey($token);
-		
-		//Validate key
+
+        //Get API token from request
+        $token = $this->getKeyFromRequest($request);
+
+        //Check for presence of key
+        if (!$token) return $this->unauthorizedResponse();
+
+        //Get API key
+        $apiKey = ApiKey::getByKey($token);
+
+        //Validate key
         if (!($apiKey instanceof ApiKey)) return $this->unauthorizedResponse();
 
         //Get the model
         $keyable = $apiKey->keyable;
-        
+
         //Validate model
         if (config('keyable.allow_empty_models', false)) {
-	        
-	        if (!$keyable && (!is_null($apiKey->keyable_type) || !is_null($apiKey->keyable_id)))
-	        	return $this->unauthorizedResponse();
-	        
+
+            if (!$keyable && (!is_null($apiKey->keyable_type) || !is_null($apiKey->keyable_id)))
+                return $this->unauthorizedResponse();
+
         } else {
-	        
-	        if (!$keyable) 
-	        	return $this->unauthorizedResponse();
-	        
+
+            if (!$keyable)
+                return $this->unauthorizedResponse();
+
         }
-        
+
         //Attach the apikey object to the request
         $request->apiKey = $apiKey;
         if ($keyable) $request->keyable = $keyable;
-        
+
         //Update last_used_at
         $apiKey->markAsUsed();
-		
-		//Return
+
+        //Return
         return $next($request);
-        
+
     }
-    
+
     protected function getKeyFromRequest($request)
     {
-	    $mode = config('keyable.mode', 'bearer');
-	    switch ($mode) {
-		    case "bearer":
-		    	return $request->bearerToken();
-		    	break;
-		    case "header":
-		    	return $request->header(config('keyable.key', 'X-Authorization'));
-		    	break;
-		    case "parameter":
-		    	return $request->input(config('keyable.key', 'api_key'));
-		    	break;
-	    }
+        // Retrieve modes from config
+        $modes = config('keyable.modes', 'bearer');
+
+        // Bearer check
+        if (
+            in_array('bearer', $modes) &&
+            !is_null($request->bearerToken())
+        ) {
+            return $request->bearerToken();
+        }
+
+        // Header check
+        if (
+            in_array('header', $modes) &&
+            !is_null($request->header(config('keyable.key', 'X-Authorization')))
+        ) {
+            return $request->header(config('keyable.key', 'X-Authorization'));
+        }
+
+        // Paramter check
+        if (
+            in_array('parameter', $modes) &&
+            !is_null($request->input(config('keyable.key', 'api_key')))
+        ) {
+            return $request->input(config('keyable.key', 'api_key'));
+        }
     }
-    
-    protected function unauthorizedResponse()
+
+    protected
+    function unauthorizedResponse()
     {
         return response([
             'error' => [

--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -79,7 +79,7 @@ class AuthenticateApiKey
             return $request->header(config('keyable.key', 'X-Authorization'));
         }
 
-        // Paramter check
+        // Parameter check
         if (
             in_array('parameter', $modes) &&
             !is_null($request->input(config('keyable.key', 'api_key')))


### PR DESCRIPTION
Hello, I'm using your package for a project I'm working on and I currently stumbled on the fact that you does not support that we provide a token both from Bearer (can be useful for SPAs for example) and from inline parameters (can be useful for webhooks or any other inline querying service).

I just modified the `mode` key to `modes` and added the according behaviour in `getKeyFromRequest` method inside ÀuthenticateApiKey`.

I hope it'll seems great to you.

Thank your for this package.