### PR TITLE
Keyable scope

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Add API keys to your Laravel models",
     "license": "MIT",
     "keywords": [
-    	"laravel", 
-    	"php", 
+    	"laravel",
+    	"php",
     	"api",
     	"rest",
     	"json",
@@ -21,13 +21,18 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-	    "php": "^7.0|^8.0"
+	    "php": "^7.0|^8.0",
+        "orchestra/testbench": "^6.23",
+        "phpunit/phpunit": "^9.5"
     },
-    "require-dev": {
-	},
     "autoload": {
         "psr-4": {
             "Givebutter\\LaravelKeyable\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Givebutter\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/src/Http/Middleware/EnforceKeyableScope.php
+++ b/src/Http/Middleware/EnforceKeyableScope.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Givebutter\LaravelKeyable\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Reflector;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class EnforceKeyableScope
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param Closure                  $next
+     * @param string|null              $guard
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $guard = null)
+    {
+        $route = $request->route();
+
+        if (empty($route->parameterNames())) {
+            return $next($request);
+        }
+
+
+        $parameterName = $route->parameterNames()[0];
+        $parameter = $route->parameters()[$parameterName];
+
+        if (! is_object($parameter)) {
+            $parameter = Arr::first($route->signatureParameters(UrlRoutable::class));
+            $instance = app(Reflector::getParameterClassName($parameter));
+
+            $routeBindingMethod = $route->allowsTrashedBindings()
+                        ? 'resolveSoftDeletableRouteBinding'
+                        : 'resolveRouteBinding';
+
+            $instance->{$routeBindingMethod}($parameter, $route->bindingFieldFor($parameterName));
+        }
+
+        $childRouteBindingMethod = $route->allowsTrashedBindings()
+                ? 'resolveSoftDeletableChildRouteBinding'
+                : 'resolveChildRouteBinding';
+
+        if (! $request->keyable->{$childRouteBindingMethod}(
+            $parameterName,
+            $parameter->id,
+            $route->bindingFieldFor($parameterName)
+        )) {
+            throw (new ModelNotFoundException)->setModel(get_class($parameter), [$parameter->id]);
+        }
+
+        return $next($request);
+    }
+
+    protected static function getParameterName($name, $parameters)
+    {
+        if (array_key_exists($name, $parameters)) {
+            return $name;
+        }
+
+        if (array_key_exists($snakedName = Str::snake($name), $parameters)) {
+            return $snakedName;
+        }
+    }
+}

--- a/src/KeyableServiceProvider.php
+++ b/src/KeyableServiceProvider.php
@@ -2,11 +2,14 @@
 
 namespace Givebutter\LaravelKeyable;
 
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Routing\PendingResourceRegistration;
 use Givebutter\LaravelKeyable\Console\Commands\DeleteApiKey;
 use Givebutter\LaravelKeyable\Console\Commands\GenerateApiKey;
 use Givebutter\LaravelKeyable\Http\Middleware\AuthenticateApiKey;
-use Illuminate\Routing\Router;
-use Illuminate\Support\ServiceProvider;
+use Givebutter\LaravelKeyable\Http\Middleware\EnforceKeyableScope;
 
 class KeyableServiceProvider extends ServiceProvider
 {
@@ -20,12 +23,14 @@ class KeyableServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/keyable.php' => config_path('keyable.php'),
         ]);
-        
+
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
-        
+
         $this->registerMiddleware($router);
-        
+
         $this->registerCommands();
+
+        $this->registerMacros();
     }
 
     /**
@@ -37,7 +42,7 @@ class KeyableServiceProvider extends ServiceProvider
     {
         //
     }
-    
+
     protected function registerCommands()
     {
         if ($this->app->runningInConsole()) {
@@ -47,7 +52,7 @@ class KeyableServiceProvider extends ServiceProvider
             ]);
         }
     }
-    
+
     /**
      * Register middleware.
      *
@@ -60,8 +65,25 @@ class KeyableServiceProvider extends ServiceProvider
         $versionComparison = version_compare(app()->version(), '5.4.0');
         if ($versionComparison >= 0) {
             $router->aliasMiddleware('auth.apikey', AuthenticateApiKey::class);
+            $router->aliasMiddleware('keyableScoped', EnforceKeyableScope::class);
         } else {
             $router->middleware('auth.apikey', AuthenticateApiKey::class);
+            $router->middleware('keyableScoped', EnforceKeyableScope::class);
         }
+    }
+
+    protected function registerMacros()
+    {
+        PendingResourceRegistration::macro('keyableScoped', function () {
+            $this->middleware('keyableScoped');
+
+            return $this;
+        });
+
+        Route::macro('keyableScoped', function () {
+            $this->middleware('keyableScoped');
+
+            return $this;
+        });
     }
 }

--- a/tests/Feature/AuthenticateApiKey.php
+++ b/tests/Feature/AuthenticateApiKey.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Givebutter\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Givebutter\Tests\TestCase;
+use Givebutter\Tests\Support\Account;
+use Illuminate\Support\Facades\Route;
+
+class AuthenticateApiKey extends TestCase
+{
+    /** @test */
+    public function request_with_api_key_responds_ok()
+    {
+        $account = Account::create();
+        $account->createApiKey();
+
+        Route::get("/api/posts", function (Request $request) {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $account->apiKeys()->first()->key,
+        ])->get("/api/posts")->assertOk();
+    }
+
+    /** @test */
+    public function request_without_api_key_responds_unauthorized()
+    {
+        $account = Account::create();
+        $account->createApiKey();
+
+        Route::get("/api/posts", function (Request $request) {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->get("/api/posts")->assertUnauthorized();
+    }
+}

--- a/tests/Feature/EnforceKeyableScope.php
+++ b/tests/Feature/EnforceKeyableScope.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Givebutter\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Givebutter\Tests\TestCase;
+use Givebutter\Tests\Support\Post;
+use Givebutter\Tests\Support\Account;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class EnforceKeyableScope extends TestCase
+{
+    /** @test */
+    public function request_with_parameter_must_be_owned_by_keyable()
+    {
+        $account = Account::create();
+        $account->createApiKey();
+
+        $post = $account->posts()->create();
+
+        Route::get("/api/posts/{post}", function (Request $request, Post $post) {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey'])->keyableScoped();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $account->apiKeys()->first()->key,
+        ])->get("/api/posts/{$post->id}")->assertOk();
+    }
+
+    /** @test */
+    public function request_with_model_not_owned_by_keyable_throws_model_not_found()
+    {
+        $account = Account::create();
+        $account->createApiKey();
+
+        $account2 = Account::create();
+        $post = $account2->posts()->create();
+
+        Route::get("/api/posts/{post}", function (Request $request, Post $post) {
+            return response('All good', 200);
+        })->middleware([ 'api', 'auth.apikey'])->keyableScoped();
+
+        try {
+            $this->withHeaders([
+                'Authorization' => 'Bearer ' . $account->apiKeys()->first()->key,
+            ])->get("/api/posts/{$post->id}");
+        } catch (ModelNotFoundException $e) {
+            $this->assertTrue(true);
+            return;
+        }
+
+        // force a fail since it shouldn't reach this point.
+        $this->assertTrue(false);
+    }
+}

--- a/tests/Support/Account.php
+++ b/tests/Support/Account.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Givebutter\Tests\Support;
+
+use Givebutter\LaravelKeyable\Keyable;
+use Illuminate\Database\Eloquent\Model;
+
+class Account extends Model
+{
+    use Keyable;
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/tests/Support/Migrations/create_accounts_and_posts_tables.php
+++ b/tests/Support/Migrations/create_accounts_and_posts_tables.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAccountsAndPostsTables extends Migration
+{
+    public function up()
+    {
+        Schema::create('accounts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('account_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('accounts');
+        Schema::dropIfExists('posts');
+    }
+}

--- a/tests/Support/Post.php
+++ b/tests/Support/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Givebutter\Tests\Support;
+
+use Givebutter\Tests\Support\Account;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function account()
+    {
+        return $this->belongsTo(Account::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Givebutter\Tests;
+
+use Illuminate\Support\Str;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Givebutter\LaravelKeyable\KeyableServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+class TestCase extends OrchestraTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Factory::guessFactoryNamesUsing(function (string $modelName) {
+            $namespace = 'Database\\Factories\\';
+
+            $modelName = Str::afterLast($modelName, '\\');
+
+            return $namespace.$modelName.'Factory';
+        });
+
+        $this->setUpDatabase($this->app);
+        $this->withoutExceptionHandling();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            KeyableServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    protected function setUpDatabase($app)
+    {
+        $app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->prepareDatabaseForHasCustomFieldsModel();
+        $this->runMigrationStub();
+    }
+
+    protected function runMigrationStub()
+    {
+        include_once __DIR__ . '/../database/migrations/2019_04_09_225232_create_api_keys_table.php';
+        (new \CreateApiKeysTable())->up();
+    }
+
+    protected function prepareDatabaseForHasCustomFieldsModel()
+    {
+        include_once __DIR__ . '/../tests/Support/Migrations/create_accounts_and_posts_tables.php';
+        (new \CreateAccountsAndPostsTables())->up();
+    }
+
+    protected function resetDatabase()
+    {
+        $this->artisan('migrate:fresh');
+        $this->runMigrationStub();
+    }
+}


### PR DESCRIPTION
### This PR...

Adds a `keyableScoped` macro to routes to check whether the first URI parameter belongs to the keyable model.

For example, given a route...

```
Route::get('posts/{post}', function () {
  //
})->keyableScoped();
```

The `keyableScoped` method is an alias for adding the `EnforceKeyableScope` middleware. This will check that the `Post` model that is provided is an existing relationship on the `$request->keyable` model.

### Todo

- [ ] Update Readme