### PR TITLE
Fix ofKey scope

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.0|^8.0",
-        "doctrine/dbal": "^3.7"
+        "php": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Models/ApiKey.php
+++ b/src/Models/ApiKey.php
@@ -105,13 +105,12 @@ class ApiKey extends Model
 
         if ($compatibilityMode) {
             return $query->where(function (Builder $query) use ($key) {
-                if ($this->isMissingId($key)) {
+                if (! str_contains($key, '|')) {
                     return $query->where('key', $key)
                         ->orWhere('key', hash('sha256', $key));
                 }
 
-                $id = $this->extractId($key);
-                $key = $this->extractKey($key);
+                [$id, $key] = explode('|', $key, 2);
 
                 return $query
                     ->where(function (Builder $query) use ($key, $id) {
@@ -125,26 +124,13 @@ class ApiKey extends Model
             });
         }
 
-        if ($this->isMissingId($key)) {
+        if (! str_contains($key, '|')) {
             return $query->where('key', hash('sha256', $key));
         }
 
-        return $query->where('id', $this->extractId($key))
-            ->where('key', hash('sha256', $this->extractKey($key)));
-    }
+        [$id, $key] = explode('|', $key, 2);
 
-    private function isMissingId(string $key): bool
-    {
-        return strpos($key, '|') === false;
-    }
-
-    private function extractId(string $key): string
-    {
-        return explode('|', $key, 2)[0];
-    }
-
-    private function extractKey(string $key): string
-    {
-        return explode('|', $key, 2)[1];
+        return $query->where('id', $id)
+            ->where('key', hash('sha256', $key));
     }
 }

--- a/tests/Feature/CompatibilityMode.php
+++ b/tests/Feature/CompatibilityMode.php
@@ -71,14 +71,24 @@ class CompatibilityMode extends TestCase
             'key' => $apiKey2->fresh()->key,
         ]);
 
-        // Assert the non hashed api keys works
+        // Assert that non hashed api keys works
         $this->withHeaders([
-            'Authorization' => 'Bearer ' . $plainTextApiKey1,
+            'Authorization' => "Bearer {$plainTextApiKey1}",
         ])->get("/api/posts/{$post->id}")->assertOk();
 
-        // Assert the hashed api keys works
+        // Assert that non hashed api keys with ID prefix works
         $this->withHeaders([
-            'Authorization' => 'Bearer ' . $plainTextApiKey2,
+            'Authorization' => "Bearer {$apiKey1->id}|{$plainTextApiKey1}",
+        ])->get("/api/posts/{$post->id}")->assertOk();
+
+        // Assert that hashed api keys works
+        $this->withHeaders([
+            'Authorization' => "Bearer {$plainTextApiKey2}",
+        ])->get("/api/posts/{$post->id}")->assertOk();
+
+        // Assert that hashed api keys with ID prefix works
+        $this->withHeaders([
+            'Authorization' => "Bearer {$apiKey2->id}|{$plainTextApiKey2}",
         ])->get("/api/posts/{$post->id}")->assertOk();
     }
 }


### PR DESCRIPTION
This PR fixes the `ofKey` scope query when the `key` is prefixed with its `id` and `compatibility_mode` is enabled.