### PR TITLE
Feature/add key mode choice in middleware

### DIFF
--- a/config/keyable.php
+++ b/config/keyable.php
@@ -17,6 +17,10 @@ return [
 
     'key' => null,
 
+    'key-header' => null,
+
+    'key-parameter' => null,
+
     /*
     |--------------------------------------------------------------------------
     | Empty Models

--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -12,14 +12,15 @@ class AuthenticateApiKey
      *
      * @param \Illuminate\Http\Request $request
      * @param Closure                  $next
+     * @param string|null              $mode
      * @param string|null              $guard
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next, ?string $mode = null, $guard = null)
     {
         //Get API token from request
-        $token = $this->getKeyFromRequest($request);
+        $token = $this->getKeyFromRequest($request, $mode);
 
         //Check for presence of key
         if (! $token) {
@@ -61,19 +62,19 @@ class AuthenticateApiKey
         return $next($request);
     }
 
-    protected function getKeyFromRequest($request)
+    protected function getKeyFromRequest($request, $mode)
     {
-        $mode = config('keyable.mode', 'bearer');
+        $mode = $mode ?? config('keyable.mode', 'bearer');
 
         switch ($mode) {
             case 'bearer':
                 return $request->bearerToken();
                 break;
             case 'header':
-                return $request->header(config('keyable.key', 'X-Authorization'));
+                return $request->header(config('keyable.key-' . $mode, config('keyable.key', 'X-Authorization')));
                 break;
             case 'parameter':
-                return $request->input(config('keyable.key', 'api_key'));
+                return $request->input(config('keyable.key-' . $mode, config('keyable.key', 'api_key')));
                 break;
         }
     }

--- a/tests/Feature/AuthenticateApiKey.php
+++ b/tests/Feature/AuthenticateApiKey.php
@@ -21,6 +21,17 @@ class AuthenticateApiKey extends TestCase
             'Authorization' => 'Bearer ' . $account->createApiKey()->plainTextApiKey,
         ])->get("/api/posts")->assertOk();
     }
+    /** @test */
+    public function request_with_api_key_responds_ok_in_param_mode()
+    {
+        Route::get("/api/posts", function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey:parameter']);
+
+        $account = Account::create();
+
+        $this->get("/api/posts?api_key=" . $account->createApiKey()->plainTextApiKey)->assertOk();
+    }
 
     /** @test */
     public function request_with_valid_api_key_without_id_prefix_responds_ok()
@@ -80,5 +91,19 @@ class AuthenticateApiKey extends TestCase
         })->middleware(['api', 'auth.apikey']);
 
         $this->get("/api/posts")->assertUnauthorized();
+    }
+
+    /** @test */
+    public function request_without_api_key_properly_set_responds_unauthorized()
+    {
+        Route::get("/api/posts", function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey:parameter']);
+
+        $account = Account::create();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer ' . $account->createApiKey()->plainTextApiKey,
+        ])->get("/api/posts")->assertUnauthorized();
     }
 }


### PR DESCRIPTION
I have a use case where I need to use Bearer, header and parameter authentication for different groups of routes.

This PR should make that possible using `auth.apikey:parameter` or `auth.apikey:header`. Default still is Bearer mode.