### PR TITLE
Security improvements

### DIFF
--- a/src/Exceptions/ForbidenRequestParamException.php
+++ b/src/Exceptions/ForbidenRequestParamException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Givebutter\LaravelKeyable\Exceptions;
+
+class ForbidenRequestParamException extends \Exception
+{
+    //
+}

--- a/src/Exceptions/ForbidenRequestParamException.php
+++ b/src/Exceptions/ForbidenRequestParamException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Givebutter\LaravelKeyable\Exceptions;
-
-class ForbidenRequestParamException extends \Exception
-{
-    //
-}

--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -3,7 +3,9 @@
 namespace Givebutter\LaravelKeyable\Http\Middleware;
 
 use Closure;
+use Givebutter\LaravelKeyable\Exceptions\ForbidenRequestParamException;
 use Givebutter\LaravelKeyable\Models\ApiKey;
+use Illuminate\Http\Request;
 
 class AuthenticateApiKey
 {
@@ -18,6 +20,8 @@ class AuthenticateApiKey
      */
     public function handle($request, Closure $next, $guard = null)
     {
+        $this->checkForbidenRequestParams($request);
+
         //Get API token from request
         $token = $this->getKeyFromRequest($request);
 
@@ -85,5 +89,18 @@ class AuthenticateApiKey
                 'message' => 'Unauthorized',
             ],
         ], 401);
+    }
+
+    private function checkForbidenRequestParams(Request $request): void
+    {
+        $forbidenParams = ['apiKey', 'keyable'];
+
+        foreach ($forbidenParams as $forbidenParam) {
+            if ($request->missing($forbidenParam)) {
+                continue;
+            }
+
+            throw new ForbidenRequestParamException("Request param '{$forbidenParam}' is not allowed.");
+        }
     }
 }

--- a/tests/Feature/AuthenticateApiKey.php
+++ b/tests/Feature/AuthenticateApiKey.php
@@ -93,7 +93,9 @@ class AuthenticateApiKey extends TestCase
             return response('All good', 200);
         })->middleware(['api', 'auth.apikey']);
 
-        $this->get("/api/posts?{$queryParam}=value")->assertInternalServerError();
+        $this->get("/api/posts?{$queryParam}=value")
+            ->assertBadRequest()
+            ->assertContent("Request param '{$queryParam}' is not allowed.");
     }
 
     /**
@@ -106,7 +108,39 @@ class AuthenticateApiKey extends TestCase
             return response('All good', 200);
         })->middleware(['api', 'auth.apikey']);
 
-        $this->post('/api/posts', [$bodyParam => 'value'])->assertInternalServerError();
+        $this->post('/api/posts', [$bodyParam => 'value'])
+            ->assertBadRequest()
+            ->assertContent("Request param '{$bodyParam}' is not allowed.");
+    }
+
+    /**
+     * @test
+     * @dataProvider forbiddenRequestParams
+     */
+    public function throw_exception_if_unauthorized_json_get_request_has_forbidden_request_query_params(string $queryParam): void
+    {
+        Route::get('/api/posts', function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->getJson("/api/posts?{$queryParam}=value")
+            ->assertBadRequest()
+            ->assertJson(['message' => "Request param '{$queryParam}' is not allowed."]);
+    }
+
+    /**
+     * @test
+     * @dataProvider forbiddenRequestParams
+     */
+    public function throw_exception_if_unauthorized_json_post_request_has_forbidden_request_body_params(string $bodyParam): void
+    {
+        Route::post('/api/posts', function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->postJson('/api/posts', [$bodyParam => 'value'])
+            ->assertBadRequest()
+            ->assertJson(['message' => "Request param '{$bodyParam}' is not allowed."]);
     }
 
     public function forbiddenRequestParams(): array

--- a/tests/Feature/AuthenticateApiKey.php
+++ b/tests/Feature/AuthenticateApiKey.php
@@ -2,6 +2,7 @@
 
 namespace Givebutter\Tests\Feature;
 
+use Givebutter\LaravelKeyable\Exceptions\ForbidenRequestParamException;
 use Givebutter\Tests\TestCase;
 use Givebutter\Tests\Support\Account;
 use Illuminate\Support\Facades\Route;
@@ -80,5 +81,39 @@ class AuthenticateApiKey extends TestCase
         })->middleware(['api', 'auth.apikey']);
 
         $this->get("/api/posts")->assertUnauthorized();
+    }
+
+    /**
+     * @test
+     * @dataProvider forbiddenRequestParams
+     */
+    public function throw_exception_if_unauthorized_get_request_has_forbidden_request_query_params(string $queryParam): void
+    {
+        Route::get('/api/posts', function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->get("/api/posts?{$queryParam}=value")->assertInternalServerError();
+    }
+
+    /**
+     * @test
+     * @dataProvider forbiddenRequestParams
+     */
+    public function throw_exception_if_unauthorized_post_request_has_forbidden_request_body_params(string $bodyParam): void
+    {
+        Route::post('/api/posts', function () {
+            return response('All good', 200);
+        })->middleware(['api', 'auth.apikey']);
+
+        $this->post('/api/posts', [$bodyParam => 'value'])->assertInternalServerError();
+    }
+
+    public function forbiddenRequestParams(): array
+    {
+        return [
+            ['keyable'],
+            ['apiKey'],
+        ];
     }
 }


### PR DESCRIPTION
- Throw exception if request has parameters that are not allowed.
  - `kayable`
  - `apiKey`

<img width="1512" alt="Screen Shot 2024-10-11 at 16 51 31" src="https://github.com/user-attachments/assets/eb75c504-8305-4be4-81ce-4eadf365b061">

